### PR TITLE
Add device-aware inference compatibility

### DIFF
--- a/src/json2vec/architecture/root.py
+++ b/src/json2vec/architecture/root.py
@@ -63,7 +63,7 @@ def step(
         loss_fn = cast(Callable[..., torch.Tensor], getattr(extension, "loss"))
 
         loss: torch.Tensor = loss_fn(module=module, prediction=prediction, batch=batch[address], strata=strata)
-        losses.append(loss * torch.tensor(request.weight))
+        losses.append(loss * loss.new_tensor(request.weight))
 
     if len(losses) == 0:
         # under idealistic circumstances this would never happen.
@@ -146,6 +146,15 @@ class JSON2Vec(lit.LightningModule):
             for address, node in self.nodes.items()
             if hasattr(node, "embedder") and hasattr(node.embedder, "state")
         }
+
+    def _module_device(self) -> torch.device:
+        for parameter in self.parameters():
+            return parameter.device
+
+        for buffer in self.buffers():
+            return buffer.device
+
+        return torch.device("cpu")
 
     def plot(
         self,
@@ -415,7 +424,7 @@ class JSON2Vec(lit.LightningModule):
             hyperparameters=self.hyperparameters,
             strata=Strata.predict,
             state=self.state,
-        )
+        ).to(self._module_device())
 
         self.eval()
         try:

--- a/src/json2vec/inference/deployment.py
+++ b/src/json2vec/inference/deployment.py
@@ -4,6 +4,7 @@ import litserve as ls
 import pydantic
 import torch
 from beartype import beartype
+from loguru import logger
 from pydantic import AliasChoices, Field, ValidationInfo, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from tensordict import TensorDict
@@ -23,6 +24,35 @@ def default_dataset() -> Dataset:
         root=None,
         processor="default",
     )
+
+
+def _mps_available() -> bool:
+    return bool(hasattr(torch.backends, "mps") and torch.backends.mps.is_available())
+
+
+def resolve_accelerator(accelerator: Literal["auto", "cpu", "cuda", "mps"]) -> Literal["cpu", "cuda", "mps"]:
+    if accelerator == "auto":
+        if torch.cuda.is_available():
+            return "cuda"
+
+        if _mps_available():
+            return "mps"
+
+        return "cpu"
+
+    if accelerator == "cuda" and not torch.cuda.is_available():
+        logger.bind(component="deployment", accelerator=accelerator, fallback="cpu").warning(
+            "requested accelerator is unavailable; falling back to CPU"
+        )
+        return "cpu"
+
+    if accelerator == "mps" and not _mps_available():
+        logger.bind(component="deployment", accelerator=accelerator, fallback="cpu").warning(
+            "requested accelerator is unavailable; falling back to CPU"
+        )
+        return "cpu"
+
+    return accelerator
 
 
 class DeploymentEnvironment(BaseSettings):
@@ -218,7 +248,7 @@ class Deployment(ls.LitAPI):
                 max_batch_size=environment.max_batch_size,
                 batch_timeout=environment.batch_timeout,
             ),
-            accelerator=environment.accelerator,
+            accelerator=resolve_accelerator(environment.accelerator),
             track_requests=environment.track_requests,
             workers_per_device=environment.workers_per_device,
         )

--- a/tests/architecture/test_root.py
+++ b/tests/architecture/test_root.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Callable
 
+import pytest
 import torch
 
 from json2vec.architecture.root import JSON2Vec
@@ -217,3 +219,53 @@ def test_embed_encodes_batch_and_returns_embedding_outputs() -> None:
     embedding = embeddings[Address("root")]["embedding"]
     assert len(embedding) == 2
     assert all(not isinstance(row[0], list) for row in embedding)
+
+
+def _assert_inference_inputs_move_to_model_device(device: torch.device, monkeypatch: pytest.MonkeyPatch) -> None:
+    model = _primed_prediction_model().to(device)
+    original_forward: Callable = model.forward
+    expected_type = device.type
+
+    def checked_forward(inputs):
+        for address in model.hyperparameters.requests:
+            field = inputs[address]
+            assert field.state.device.type == expected_type
+            assert field.content.device.type == expected_type
+            assert field.trainable.device.type == expected_type
+
+        return original_forward(inputs)
+
+    monkeypatch.setattr(model, "forward", checked_forward)
+
+    supervised = model.predict(
+        batch=[
+            [{"color": "red"}],
+            [{"color": "blue"}],
+        ]
+    )
+    embeddings = model.embed(
+        batch=[
+            [{"color": "red"}],
+            [{"color": "blue"}],
+        ]
+    )
+
+    assert Address("root", "label") in supervised
+    assert Address("root") in embeddings
+
+
+def test_predict_and_embed_move_encoded_inputs_to_cpu_model_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    _assert_inference_inputs_move_to_model_device(torch.device("cpu"), monkeypatch)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_predict_and_embed_move_encoded_inputs_to_cuda_model_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    _assert_inference_inputs_move_to_model_device(torch.device("cuda"), monkeypatch)
+
+
+@pytest.mark.skipif(
+    not (hasattr(torch.backends, "mps") and torch.backends.mps.is_available()),
+    reason="MPS is not available",
+)
+def test_predict_and_embed_move_encoded_inputs_to_mps_model_device(monkeypatch: pytest.MonkeyPatch) -> None:
+    _assert_inference_inputs_move_to_model_device(torch.device("mps"), monkeypatch)

--- a/tests/structs/test_environment.py
+++ b/tests/structs/test_environment.py
@@ -1,7 +1,8 @@
 import pytest
+import torch
 from pydantic import ValidationError
 
-from json2vec.inference.deployment import DeploymentEnvironment
+from json2vec.inference.deployment import DeploymentEnvironment, resolve_accelerator
 
 ENV_VARS = (
     "JSON2VEC_CHECKPOINT",
@@ -39,3 +40,36 @@ def test_deployment_environment_invalid_accelerator_raises(monkeypatch: pytest.M
 
     with pytest.raises(ValidationError, match="JSON2VEC_ACCELERATOR"):
         DeploymentEnvironment()
+
+
+def test_resolve_accelerator_auto_prefers_cuda(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+
+    assert resolve_accelerator("auto") == "cuda"
+
+
+def test_resolve_accelerator_auto_uses_mps_when_cuda_is_unavailable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+
+    assert resolve_accelerator("auto") == "mps"
+
+
+def test_resolve_accelerator_auto_uses_cpu_when_no_accelerator_is_available(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+
+    assert resolve_accelerator("auto") == "cpu"
+
+
+def test_resolve_accelerator_falls_back_from_unavailable_cuda(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    assert resolve_accelerator("cuda") == "cpu"
+
+
+def test_resolve_accelerator_falls_back_from_unavailable_mps(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+
+    assert resolve_accelerator("mps") == "cpu"


### PR DESCRIPTION
## Summary

- Add device-aware direct inference for `JSON2Vec.predict()`, `embed()`, and `evaluate()`.
- Move encoded inference batches to the model's current PyTorch device.
- Add deployment accelerator resolution with CPU fallback for unavailable CUDA/MPS.
- Add CPU, MPS, CUDA-skipped, and accelerator fallback test coverage.

## Testing

- `uv run pytest tests/architecture/test_root.py tests/inference/test_deployment_batching.py tests/structs/test_environment.py`
- `uv run ruff check src/json2vec/architecture/root.py src/json2vec/inference/deployment.py tests/architecture/test_root.py tests/structs/test_environment.py`
- `uv run pytest`