### PR TITLE
[codex] Fix deployment batch concatenation

### DIFF
--- a/src/json2vec/inference/deployment.py
+++ b/src/json2vec/inference/deployment.py
@@ -16,7 +16,7 @@ from tensordict import TensorDict
 
 from json2vec.architecture.root import Model
 from json2vec.data.iterables import JMESPathResolutionMonitor, encode
-from json2vec.structs.enums import Strata
+from json2vec.structs.enums import Strata, TensorKey
 from json2vec.structs.experiment import NodeAttribute, NodePredicate
 from json2vec.structs.packages import Prediction
 from json2vec.structs.tree import Address, Node
@@ -56,6 +56,38 @@ class BatchItem(pydantic.BaseModel):
     data: Input | None
     valid_indices: list[int]
     items: list[Input | ErrorItem]
+
+
+def _input_batch_size(item: Input) -> int:
+    if len(item.batch_size) > 0:
+        return int(item.batch_size[0])
+
+    for key, value in item.items():
+        if key == TensorKey.metadata:
+            continue
+
+        batch_size = getattr(value, "batch_size", ())
+        if len(batch_size) > 0:
+            return int(batch_size[0])
+
+        if torch.is_tensor(value) and value.ndim > 0:
+            return int(value.shape[0])
+
+    return 1
+
+
+def _cat_inputs(inputs: list[Input]) -> Input:
+    out: dict[Address, TensorFieldBase] = {}
+
+    for key in inputs[0].keys():
+        if key == TensorKey.metadata:
+            continue
+
+        address = Address(str(key))
+        out[address] = torch.cat([item[key] for item in inputs], dim=0)
+
+    batch_size = sum(_input_batch_size(item) for item in inputs)
+    return cast(Input, TensorDict(source=cast(Any, out), batch_size=[batch_size]))
 
 
 class API(ls.LitAPI):
@@ -170,7 +202,7 @@ class API(ls.LitAPI):
             valid_indices.append(index)
             valid_inputs.append(item)
 
-        data = torch.stack(valid_inputs, dim=0) if valid_inputs else None
+        data = _cat_inputs(valid_inputs) if valid_inputs else None
         return BatchItem(data=data, valid_indices=valid_indices, items=inputs)
 
     @beartype

--- a/tests/inference/test_deployment_batching.py
+++ b/tests/inference/test_deployment_batching.py
@@ -72,6 +72,35 @@ def test_deployment_batches_only_valid_inputs_and_preserves_per_item_errors():
     assert encoded[2]["predictions"]["root/label"]["value"] == "ok"
 
 
+def test_deployment_batches_real_encoded_requests_without_extra_tensor_rank():
+    model = Model.from_schema(
+        Number(name="amount"),
+        d_model=8,
+        n_layers=1,
+        n_heads=2,
+        batch_size=2,
+        embed=True,
+    )
+    deployment = API(model=model)
+    deployment.setup(device="cpu")
+
+    first = deployment.decode_request({"amount": 1.5})
+    second = deployment.decode_request({"amount": 2.5})
+
+    assert isinstance(first, TensorDict)
+    assert isinstance(second, TensorDict)
+
+    batch = deployment.batch([first, second])
+
+    assert batch.data is not None
+    assert batch.data["record/amount"].state.shape == torch.Size([2, 1])
+
+    outputs = deployment.predict(batch)
+
+    assert len(outputs) == 2
+    assert all(isinstance(item, list) for item in outputs)
+
+
 def test_deployment_postprocess_can_rewrite_encoded_response():
     seen = {}
 


### PR DESCRIPTION
## Summary

Fix LitServe request batching so independently encoded requests are concatenated along their existing batch dimension instead of stacked into an extra tensor rank.

## Root Cause

`API.batch(...)` previously called `torch.stack(valid_inputs, dim=0)` on per-request encoded `TensorDict` objects. Each decoded request already contains a batch dimension of size 1, so stacking produced tensors shaped like `[lit_batch, 1, ...]`. The model forward contract expects `[batch, ...]`, which caused batched serving to fail with a rank error.

## Changes

- Add a small batching helper that concatenates each encoded field with `torch.cat(..., dim=0)`.
- Exclude request metadata from the model-facing batched input while preserving original per-item inputs in `BatchItem.items`.
- Add a regression test that runs real `API.decode_request -> API.batch -> API.predict` with a real `Model`.

## Validation

- `uv run pytest tests/inference/test_deployment_batching.py`
- `uv run ruff check`
- `uv run pytest`
