### PR TITLE
Implementation of CosFace algorithm for semantic categorical embeddings

### DIFF
--- a/docs/core-concepts/embeddings.qmd
+++ b/docs/core-concepts/embeddings.qmd
@@ -188,6 +188,14 @@ device appears multiple times inside one observation and one Entity leaf. Use
 `Category` for bounded labels that should have a persistent vocabulary across
 training and prediction.
 
+`Category` content embeddings are learned directions on a unit hypersphere.
+An available valued input adds its category direction to the learned `valued`
+state embedding. Unavailable content and non-valued states add zero content,
+while retaining their appropriate state embedding. The same directions are
+used as output-class prototypes for cosine decoding. See
+[`Category`](../data-types/category.qmd#state-content-and-encoder-input) for
+the full representation and unavailable-value behavior.
+
 ## An Unsupervised Schema
 
 This sketch has no label. The model learns by reconstructing masked values,

--- a/docs/data-types/category.qmd
+++ b/docs/data-types/category.qmd
@@ -71,6 +71,8 @@ categorical content is unavailable.
 | --- | --- | --- |
 | `size` | `1024` | Maximum number of real labels in the learned vocabulary. Must be positive. There is no extra unavailable class. |
 | `p_unavailable` | `0.01` | Probability of replacing each known valued label with unavailable content during training. Must be between `0` and `1`. |
+| `scale` | `30.0` | Positive multiplier applied to cosine similarities before the content loss and prediction softmax. |
+| `margin` | `None` | CosFace margin applied to the correct category during training. `None` selects a margin from `size` and `d_model`; an explicit value must be at least `0` and less than `1`. |
 | `topk` | `[]` | Optional top-k accuracy values and prediction candidates. Values are deduplicated and sorted; each must be a positive integer other than `1` and less than `size`. |
 
 Shared options such as `target`, `p_mask`, `p_prune`, `embed`, and `weight` are
@@ -124,6 +126,54 @@ embedding returned by `embed=True`; see
 `p_unavailable` simulates the same valued-but-content-unavailable condition for
 known labels during training. It does not create a new state or teach the model
 to emit an unavailable class.
+
+## Hypersphere Decoder
+
+The content decoder emits a `d_model`-dimensional query rather than one
+independent logit per category. The query and category embeddings are
+normalized, and their cosine similarities become the class scores:
+
+$$
+\operatorname{logit}_j
+=
+\operatorname{scale}
+\left(
+\widehat{q}^{\mathsf T}\widehat{w}_j
+\right).
+$$
+
+The same category directions therefore serve two roles: they encode visible
+input labels and act as output-class prototypes. This ties input and output
+category semantics without making the decoder width depend on `size`.
+
+For an available target, training uses a CosFace-style objective. The configured
+`margin` is subtracted from the correct category's cosine similarity before
+cross entropy. A larger margin asks the decoder to separate the correct
+direction more strongly from competing directions. `scale` controls the
+sharpness of the resulting softmax.
+
+The default `margin=None` adapts the margin to vocabulary capacity and model
+dimension. It resolves to `0` for a one-label capacity, `0.5` when
+`2 <= size <= d_model + 1`, and otherwise
+`max(0.05, 0.35 * sqrt(d_model / size))`. Set an explicit margin when
+comparing experiments that must keep that geometry fixed. Setting `margin=0.0`
+removes the CosFace margin while retaining cosine classification.
+
+Training compares each valued query with all `size` category directions,
+including directions whose vocabulary slots have not been populated yet. This
+keeps the classifier shape and denominator stable while the online vocabulary
+expands. Prediction restricts candidates and probability normalization to the
+labels that have actually entered the vocabulary.
+
+An unavailable target has no category direction of its own. Its content loss
+instead encourages a uniform distribution over category directions, teaching
+the decoder not to align strongly with an arbitrary known label. Unavailable
+targets are excluded from top-1 and top-k content accuracy.
+
+Because content directions have unit norm, training also reports
+`embedding:valued_state_norm`. This makes it possible to monitor whether the
+shared `valued` state vector is becoming much larger than the category
+direction added to it.
 
 ## Loss And Metrics
 

--- a/src/relflow/tensorfields/extensions/category.py
+++ b/src/relflow/tensorfields/extensions/category.py
@@ -34,6 +34,19 @@ category: Plugin = Plugin(name="category")
 
 category.callback(VocabularySyncCallback, CounterUpdateCallback)
 
+_NORMALIZE_EPS: float = 1e-12
+
+
+def _default_margin(size: int, d_model: int) -> float:
+    if size < 2:
+        return 0.0
+
+    if size <= d_model + 1:
+        simplex_max = size / (size - 1)
+        return min(0.5, 0.5 * simplex_max)
+
+    return max(0.05, 0.35 * (d_model / size) ** 0.5)
+
 
 @category.register
 class Request(RequestBase):
@@ -47,6 +60,8 @@ class Request(RequestBase):
         pydantic.Field(alias="size", serialization_alias="size", gt=0, default=1024),
     ] = 1024
     p_unavailable: Annotated[float, pydantic.Field(ge=0.0, le=1.0, default=0.01)] = 0.01
+    scale: Annotated[float, pydantic.Field(gt=0.0, default=30.0)] = 30.0
+    margin: Annotated[float | None, pydantic.Field(ge=0.0, lt=1.0, default=None)] = None
     topk: list[int] | None = None
 
     @property
@@ -224,6 +239,11 @@ class Embedder(EmbedderBase):
         self.origin: Address = address
         self.destination: Address = request.parent.address
         self.size: int = request.size
+        self.margin: float = (
+            float(request.margin)
+            if request.margin is not None
+            else _default_margin(size=request.size, d_model=schema.d_model)
+        )
 
         self.vocab: OnlineVocabularyModel = OnlineVocabularyModel(size=request.size)
 
@@ -245,6 +265,17 @@ class Embedder(EmbedderBase):
                 TensorKey.content.name: Counter(address=address, size=request.size),
             }
         )
+        with torch.no_grad():
+            content_weight = self.embeddings[TensorKey.content.name].weight
+            content_weight.copy_(torch.nn.functional.normalize(content_weight, dim=-1, eps=_NORMALIZE_EPS))
+
+    @property
+    def content_directions(self) -> torch.Tensor:
+        return torch.nn.functional.normalize(self.embeddings[TensorKey.content.name].weight, dim=-1, eps=_NORMALIZE_EPS)
+
+    def content_cosine(self, query: torch.Tensor) -> torch.Tensor:
+        query_hat = torch.nn.functional.normalize(query, dim=-1, eps=_NORMALIZE_EPS)
+        return query_hat @ self.content_directions.T
 
     @beartype
     def forward(self, inputs: TensorFieldBase) -> Parcel:
@@ -261,7 +292,7 @@ class Embedder(EmbedderBase):
 
         known = valued & content.lt(self.size)
         safe_content = content.masked_fill(~known, 0)
-        content_embedding = self.embeddings[TensorKey.content.name](safe_content) * known.unsqueeze(-1)
+        content_embedding = self.content_directions[safe_content] * known.unsqueeze(-1)
 
         embeddings: torch.Tensor = (self.embeddings[TensorKey.state.name](state) + content_embedding).reshape(
             N, *dims, -1
@@ -284,8 +315,6 @@ class Decoder(DecoderBase):
     def __init__(self, schema: Schema, address: Address):
         super().__init__(schema=schema, address=address)
 
-        request: Request = schema.requests[address]
-
         self.linears = torch.nn.ModuleDict(
             {
                 TensorKey.state.name: torch.nn.Linear(
@@ -294,7 +323,7 @@ class Decoder(DecoderBase):
                 ),
                 TensorKey.content.name: torch.nn.Linear(
                     in_features=schema.d_model,
-                    out_features=request.size,
+                    out_features=schema.d_model,
                 ),
             }
         )
@@ -350,28 +379,40 @@ def loss(
     if not valued.any():
         return loss
 
-    content_inputs = prediction.payload[TensorKey.content].reshape(N, -1)
+    request: Request = cast(Request, module.schema.requests[prediction.address])
+    vocab_size: int = embedder.size
+    query = prediction.payload[TensorKey.content].reshape(N, -1)
     content_targets = batch.targets[TensorKey.content].reshape(N)
-    n_content_tokens = content_inputs.shape[-1]
-    invalid = valued & content_targets.gt(n_content_tokens)
+
+    invalid = valued & content_targets.gt(vocab_size)
     if invalid.any():
         raise ValueError(f"Token in address {prediction.address} exceeds vocabulary size")
 
-    known = valued & content_targets.lt(n_content_tokens)
-    unavailable = valued & content_targets.eq(n_content_tokens)
+    known = valued & content_targets.lt(vocab_size)
+    unavailable = valued & content_targets.eq(vocab_size)
 
-    content_loss_sum = content_inputs.new_zeros(())
+    cosine = embedder.content_cosine(query)
+
+    content_loss_sum = query.new_zeros(())
     if known.any():
+        cos_known = cosine[known]
+        tgt_known = content_targets[known]
+
+        one_hot = torch.zeros_like(cos_known)
+        one_hot.scatter_(1, tgt_known.unsqueeze(1), 1.0)
+        logits_known = request.scale * (cos_known - embedder.margin * one_hot)
+
         known_losses = torch.nn.functional.cross_entropy(
-            input=content_inputs[known],
-            target=content_targets[known],
+            input=logits_known,
+            target=tgt_known,
             weight=cast(Counter, embedder.counters[TensorKey.content.name]).weight,
             reduction="none",
         )
         content_loss_sum = content_loss_sum + known_losses.sum()
 
     if unavailable.any():
-        unavailable_losses = -torch.nn.functional.log_softmax(content_inputs[unavailable], dim=1).mean(dim=1)
+        logits_unavailable = request.scale * cosine[unavailable]
+        unavailable_losses = -torch.nn.functional.log_softmax(logits_unavailable, dim=1).mean(dim=1)
         content_loss_sum = content_loss_sum + unavailable_losses.sum()
 
     content_loss = module.track(
@@ -387,7 +428,7 @@ def loss(
         module.track(
             (prediction.address, strata, Metric.accuracy, f"top{topk}"),
             value=(
-                content_inputs.topk(k=topk, dim=1)
+                cosine.topk(k=topk, dim=1)
                 .indices.eq(content_targets.unsqueeze(1))
                 .any(dim=1)
                 .masked_select(known)
@@ -398,7 +439,7 @@ def loss(
 
     module.track(
         (prediction.address, strata, Metric.accuracy, TensorKey.content),
-        value=content_inputs.argmax(dim=1).eq(content_targets).masked_select(known).float().mean(),
+        value=cosine.argmax(dim=1).eq(content_targets).masked_select(known).float().mean(),
     )
 
     return loss
@@ -407,21 +448,23 @@ def loss(
 @category.register
 def write(module: Model, prediction: Prediction):
     node = module.nodes[prediction.address]
+    request: Request = cast(Request, module.schema.requests[prediction.address])
+    embedder: Embedder = node.embedder
     state_logits: torch.Tensor = prediction.payload[TensorKey.state]
-    content_logits: torch.Tensor = prediction.payload[TensorKey.content]
+    content_query: torch.Tensor = prediction.payload[TensorKey.content]
 
     tokens = np.fromiter((token.name for token in Tokens), dtype=object, count=len(Tokens))
     state_log_norm = state_logits.logsumexp(dim=-1, keepdim=True)
     state_distribution = (state_logits - state_log_norm).exp().detach().float().cpu().numpy()
     state_payload = {token: state_distribution[..., index] for index, token in enumerate(tokens.tolist())}
 
-    vocab = np.array(node.embedder.vocab.snapshot(), dtype=object)
+    vocab = np.array(embedder.vocab.snapshot(), dtype=object)
     labels = vocab
     content_shape = tuple(state_distribution.shape[:-1])
     content_labels = np.full(content_shape, None, dtype=object)
     content_probabilities = np.zeros(content_shape, dtype=np.float32)
 
-    requested_ks: list[int] = module.schema.requests[prediction.address].topk
+    requested_ks: list[int] = request.topk
     max_requested_k: int = max(requested_ks, default=0)
 
     def _pack_candidates(labels: np.ndarray, probabilities: np.ndarray) -> list[dict[str, float]] | list:
@@ -441,8 +484,10 @@ def write(module: Model, prediction: Prediction):
 
     topk_payload: list | None = _empty_candidates(content_shape)
     if len(vocab) > 0:
-        candidate_indices = torch.arange(len(vocab), device=content_logits.device, dtype=torch.int64)
-        candidate_logits = content_logits.index_select(dim=-1, index=candidate_indices)
+        candidate_indices = torch.arange(len(vocab), device=content_query.device, dtype=torch.int64)
+        directions = embedder.content_directions.index_select(dim=0, index=candidate_indices)
+        query_hat = torch.nn.functional.normalize(content_query, dim=-1, eps=_NORMALIZE_EPS)
+        candidate_logits = request.scale * (query_hat @ directions.T)
         log_norm = candidate_logits.logsumexp(dim=-1, keepdim=True)
         max_logits, max_indices = candidate_logits.max(dim=-1)
         content_probabilities = (max_logits - log_norm.squeeze(-1)).exp().detach().float().cpu().numpy()

--- a/src/relflow/tensorfields/extensions/category.py
+++ b/src/relflow/tensorfields/extensions/category.py
@@ -8,6 +8,7 @@ import numpy as np
 import pydantic
 import torch
 from beartype import beartype
+from lightning.pytorch import Callback
 from loguru import logger
 from tensordict import TensorDict, tensorclass
 
@@ -27,12 +28,12 @@ from relflow.tensorfields.shared.counter import Counter, CounterUpdateCallback
 from relflow.tensorfields.shared.vocabulary import OnlineVocabularyModel, VocabularyState, VocabularySyncCallback
 
 if TYPE_CHECKING:
+    from lightning.pytorch import Trainer
+
     from relflow.architecture.root import Model
     from relflow.structs.experiment import Schema
 
 category: Plugin = Plugin(name="category")
-
-category.callback(VocabularySyncCallback, CounterUpdateCallback)
 
 # Smaller clamps can overflow zero-query CosFace gradients in float16 at the default scale.
 _NORMALIZE_EPS: float = 1e-3
@@ -272,12 +273,16 @@ class Embedder(EmbedderBase):
 
     def content_directions(self, indices: torch.Tensor | None = None) -> torch.Tensor:
         embedding = self.embeddings[TensorKey.content.name]
-        content = embedding.weight if indices is None else embedding(indices)
-        return torch.nn.functional.normalize(content, dim=-1, eps=_NORMALIZE_EPS)
+        return embedding.weight if indices is None else embedding(indices)
 
     def content_cosine(self, query: torch.Tensor, indices: torch.Tensor | None = None) -> torch.Tensor:
         query_hat = torch.nn.functional.normalize(query, dim=-1, eps=_NORMALIZE_EPS)
         return query_hat @ self.content_directions(indices).T
+
+    @torch.no_grad()
+    def normalize_content_directions(self) -> None:
+        weight = self.embeddings[TensorKey.content.name].weight
+        weight.copy_(torch.nn.functional.normalize(weight, dim=-1, eps=_NORMALIZE_EPS))
 
     @beartype
     def forward(self, inputs: TensorFieldBase) -> Parcel:
@@ -518,3 +523,21 @@ def write(module: Model, prediction: Prediction):
             TensorKey.topk.name: topk_payload,
         },
     }
+
+
+class ContentNormalizeCallback(Callback):
+    """Renormalize categorical content directions at each train epoch end."""
+
+    @torch.no_grad()
+    def on_train_epoch_end(
+        self,
+        trainer: Trainer,
+        pl_module: Model,
+    ) -> None:  # ty:ignore[invalid-method-override]
+        for node in pl_module.nodes.values():
+            embedder = getattr(node, "embedder", None)
+            if isinstance(embedder, Embedder):
+                embedder.normalize_content_directions()
+
+
+category.callback(VocabularySyncCallback, CounterUpdateCallback, ContentNormalizeCallback)

--- a/src/relflow/tensorfields/extensions/category.py
+++ b/src/relflow/tensorfields/extensions/category.py
@@ -34,7 +34,8 @@ category: Plugin = Plugin(name="category")
 
 category.callback(VocabularySyncCallback, CounterUpdateCallback)
 
-_NORMALIZE_EPS: float = 1e-12
+# Smaller clamps can overflow zero-query CosFace gradients in float16 at the default scale.
+_NORMALIZE_EPS: float = 1e-3
 
 
 def _default_margin(size: int, d_model: int) -> float:
@@ -269,13 +270,14 @@ class Embedder(EmbedderBase):
             content_weight = self.embeddings[TensorKey.content.name].weight
             content_weight.copy_(torch.nn.functional.normalize(content_weight, dim=-1, eps=_NORMALIZE_EPS))
 
-    @property
-    def content_directions(self) -> torch.Tensor:
-        return torch.nn.functional.normalize(self.embeddings[TensorKey.content.name].weight, dim=-1, eps=_NORMALIZE_EPS)
+    def content_directions(self, indices: torch.Tensor | None = None) -> torch.Tensor:
+        embedding = self.embeddings[TensorKey.content.name]
+        content = embedding.weight if indices is None else embedding(indices)
+        return torch.nn.functional.normalize(content, dim=-1, eps=_NORMALIZE_EPS)
 
-    def content_cosine(self, query: torch.Tensor) -> torch.Tensor:
+    def content_cosine(self, query: torch.Tensor, indices: torch.Tensor | None = None) -> torch.Tensor:
         query_hat = torch.nn.functional.normalize(query, dim=-1, eps=_NORMALIZE_EPS)
-        return query_hat @ self.content_directions.T
+        return query_hat @ self.content_directions(indices).T
 
     @beartype
     def forward(self, inputs: TensorFieldBase) -> Parcel:
@@ -287,12 +289,12 @@ class Embedder(EmbedderBase):
         content = inputs.content.reshape(-1)
         valued = state.eq(Tokens.valued.value)
 
-        if valued.any() and (content.masked_select(valued) > self.size).any().item():
+        if (content.masked_select(valued) > self.size).any().item():
             raise ValueError(f"Token in address {self.origin} exceeds vocabulary size of {self.size}")
 
-        known = valued & content.lt(self.size)
-        safe_content = content.masked_fill(~known, 0)
-        content_embedding = self.content_directions[safe_content] * known.unsqueeze(-1)
+        available = valued & content.lt(self.size)
+        safe_content = content.masked_fill(~available, 0)
+        content_embedding = self.content_directions(safe_content) * available.unsqueeze(-1)
 
         embeddings: torch.Tensor = (self.embeddings[TensorKey.state.name](state) + content_embedding).reshape(
             N, *dims, -1
@@ -351,28 +353,32 @@ def loss(
 
     state_inputs = prediction.payload[TensorKey.state].reshape(N, -1)
     state_targets = batch.targets[TensorKey.state].reshape(N)
+    trainable_state_inputs = state_inputs[trainable]
+    trainable_state_targets = state_targets[trainable]
 
     loss: torch.Tensor = module.track(
         (prediction.address, strata, Metric.loss, TensorKey.state),
-        value=(
-            torch.nn.functional.cross_entropy(
-                input=state_inputs,
-                target=state_targets,
-                weight=cast(Counter, embedder.counters[TensorKey.state.name]).weight,
-                reduction="none",
-            )
-            .masked_select(trainable)
-            .mean()
-        ),
+        value=torch.nn.functional.cross_entropy(
+            input=trainable_state_inputs,
+            target=trainable_state_targets,
+            weight=cast(Counter, embedder.counters[TensorKey.state.name]).weight,
+            reduction="none",
+        ).mean(),
     )
 
     module.track(
         (prediction.address, strata, Metric.accuracy, TensorKey.state),
-        value=state_inputs.argmax(dim=1).eq(state_targets).masked_select(trainable).float().mean(),
+        value=trainable_state_inputs.argmax(dim=1).eq(trainable_state_targets).float().mean(),
     )
     module.track(
         (prediction.address, strata, "vocabulary", "size"),
         value=state_inputs.new_tensor(len(embedder.vocab.snapshot()), dtype=torch.float32),
+    )
+    with torch.no_grad():
+        valued_state_norm = embedder.embeddings[TensorKey.state.name].weight[Tokens.valued.value].norm()
+    module.track(
+        (prediction.address, strata, "embedding", "valued_state_norm"),
+        value=valued_state_norm,
     )
 
     valued = trainable & state_targets.eq(Tokens.valued.value)
@@ -383,63 +389,61 @@ def loss(
     vocab_size: int = embedder.size
     query = prediction.payload[TensorKey.content].reshape(N, -1)
     content_targets = batch.targets[TensorKey.content].reshape(N)
+    valued_query = query[valued]
+    valued_targets = content_targets[valued]
 
-    invalid = valued & content_targets.gt(vocab_size)
-    if invalid.any():
+    if valued_targets.gt(vocab_size).any():
         raise ValueError(f"Token in address {prediction.address} exceeds vocabulary size")
 
-    known = valued & content_targets.lt(vocab_size)
-    unavailable = valued & content_targets.eq(vocab_size)
+    available = valued_targets.lt(vocab_size)
+    unavailable = valued_targets.eq(vocab_size)
 
-    cosine = embedder.content_cosine(query)
+    cosine = embedder.content_cosine(valued_query)
+    cos_available = cosine[available]
+    tgt_available = valued_targets[available]
 
     content_loss_sum = query.new_zeros(())
-    if known.any():
-        cos_known = cosine[known]
-        tgt_known = content_targets[known]
-
-        one_hot = torch.zeros_like(cos_known)
-        one_hot.scatter_(1, tgt_known.unsqueeze(1), 1.0)
-        logits_known = request.scale * (cos_known - embedder.margin * one_hot)
-
-        known_losses = torch.nn.functional.cross_entropy(
-            input=logits_known,
-            target=tgt_known,
-            weight=cast(Counter, embedder.counters[TensorKey.content.name]).weight,
-            reduction="none",
+    logits_available = request.scale * cos_available
+    if embedder.margin > 0.0:
+        margin = logits_available.new_full(
+            (tgt_available.shape[0], 1),
+            -request.scale * embedder.margin,
         )
-        content_loss_sum = content_loss_sum + known_losses.sum()
+        logits_available.scatter_add_(1, tgt_available.unsqueeze(1), margin)
 
-    if unavailable.any():
-        logits_unavailable = request.scale * cosine[unavailable]
-        unavailable_losses = -torch.nn.functional.log_softmax(logits_unavailable, dim=1).mean(dim=1)
-        content_loss_sum = content_loss_sum + unavailable_losses.sum()
+    available_losses = torch.nn.functional.cross_entropy(
+        input=logits_available,
+        target=tgt_available,
+        weight=cast(Counter, embedder.counters[TensorKey.content.name]).weight,
+        reduction="none",
+    )
+    content_loss_sum = content_loss_sum + available_losses.sum()
+
+    logits_unavailable = request.scale * cosine[unavailable]
+    unavailable_losses = -torch.nn.functional.log_softmax(logits_unavailable, dim=1).mean(dim=1)
+    content_loss_sum = content_loss_sum + unavailable_losses.sum()
 
     content_loss = module.track(
         (prediction.address, strata, Metric.loss, TensorKey.content),
-        value=content_loss_sum / valued.float().sum().clamp_min(1.0),
+        value=content_loss_sum / valued_targets.numel(),
     )
     loss += content_loss
 
-    if not known.any():
+    if tgt_available.numel() == 0:
         return loss
 
-    for topk in module.schema.requests[prediction.address].topk:
+    requested_ks: list[int] = request.topk
+    top_indices = cos_available.topk(k=max(requested_ks), dim=1).indices if requested_ks else None
+    for topk in requested_ks:
+        assert top_indices is not None
         module.track(
             (prediction.address, strata, Metric.accuracy, f"top{topk}"),
-            value=(
-                cosine.topk(k=topk, dim=1)
-                .indices.eq(content_targets.unsqueeze(1))
-                .any(dim=1)
-                .masked_select(known)
-                .float()
-                .mean()
-            ),
+            value=(top_indices[:, :topk].eq(tgt_available.unsqueeze(1)).any(dim=1).float().mean()),
         )
 
     module.track(
         (prediction.address, strata, Metric.accuracy, TensorKey.content),
-        value=cosine.argmax(dim=1).eq(content_targets).masked_select(known).float().mean(),
+        value=cos_available.argmax(dim=1).eq(tgt_available).float().mean(),
     )
 
     return loss
@@ -485,9 +489,7 @@ def write(module: Model, prediction: Prediction):
     topk_payload: list | None = _empty_candidates(content_shape)
     if len(vocab) > 0:
         candidate_indices = torch.arange(len(vocab), device=content_query.device, dtype=torch.int64)
-        directions = embedder.content_directions.index_select(dim=0, index=candidate_indices)
-        query_hat = torch.nn.functional.normalize(content_query, dim=-1, eps=_NORMALIZE_EPS)
-        candidate_logits = request.scale * (query_hat @ directions.T)
+        candidate_logits = request.scale * embedder.content_cosine(content_query, indices=candidate_indices)
         log_norm = candidate_logits.logsumexp(dim=-1, keepdim=True)
         max_logits, max_indices = candidate_logits.max(dim=-1)
         content_probabilities = (max_logits - log_norm.squeeze(-1)).exp().detach().float().cpu().numpy()

--- a/tests/architecture/test_encoder.py
+++ b/tests/architecture/test_encoder.py
@@ -73,4 +73,6 @@ def test_decoder_mean_pooling_repeats_heritage_mean_for_each_target_slot():
 
     assert isinstance(decoder.pool, MeanPool)
     assert prediction.payload[TensorKey.state].shape == (2, 2, len(Tokens))
-    assert prediction.payload[TensorKey.content].shape == (2, 2, 8)
+    # CosFace: the content head emits a `d_model`-dimensional query rather
+    # than a `size`-wide logit vector.
+    assert prediction.payload[TensorKey.content].shape == (2, 2, schema.d_model)

--- a/tests/architecture/test_root.py
+++ b/tests/architecture/test_root.py
@@ -13,6 +13,7 @@ from relflow.logging.throughput import ThroughputLogger
 from relflow.structs.enums import AttentionMode, Strata, TensorKey, Tokens
 from relflow.structs.experiment import Schema
 from relflow.structs.tree import Address
+from relflow.tensorfields.extensions.category import ContentNormalizeCallback
 from relflow.tensorfields.shared.counter import CounterUpdateCallback
 from relflow.tensorfields.shared.vocabulary import (
     OnlineVocabularyModel,
@@ -372,6 +373,7 @@ def test_configure_callbacks_skips_callbacks_already_attached_to_trainer() -> No
                 ThroughputLogger(),
                 VocabularySyncCallback(),
                 CounterUpdateCallback(),
+                ContentNormalizeCallback(),
             ]
         },
     )()

--- a/tests/structs/test_rich_display.py
+++ b/tests/structs/test_rich_display.py
@@ -258,7 +258,7 @@ def test_model_select_pprint_uses_rich_node_display() -> None:
     for output in (rendered, rich_rendered):
         assert "species [category] active target query=[*].species" in output
         assert " pooling=query weight=1 p_mask=0 p_prune=1 n_heads=4 n_linear=1" in output
-        assert " size=4 p_unavailable=0.01 topk=[]" in output
+        assert " size=4 p_unavailable=0.01 scale=30 topk=[]" in output
         assert "Request(name=" not in output
         assert "Selection(" not in output
 

--- a/tests/tensorfields/extensions/test_category.py
+++ b/tests/tensorfields/extensions/test_category.py
@@ -281,7 +281,7 @@ def test_category_embedder_only_adds_content_for_available_valued_tokens():
     assert torch.all(state_gradient.abs().sum(dim=-1) > 0)
 
 
-def test_category_embedder_normalizes_looked_up_rows_instead_of_full_table(monkeypatch):
+def test_category_embedder_does_not_renormalize_content_table_at_forward(monkeypatch):
     structure = Schema.model_validate(_structure_payload(p_unavailable=0.0))
     embedder = Embedder(schema=structure, address=ADDRESS)
     field = TensorField(
@@ -291,18 +291,45 @@ def test_category_embedder_normalizes_looked_up_rows_instead_of_full_table(monke
         targets=TensorDict({}),
         batch_size=1,
     )
-    normalized_shapes: list[tuple[int, ...]] = []
+    content_weight = embedder.embeddings[TensorKey.content.name].weight
+    content_id = id(content_weight)
+    normalized_ids: list[int] = []
     normalize = torch.nn.functional.normalize
 
     def track_normalize(inputs: torch.Tensor, *args, **kwargs):
-        normalized_shapes.append(tuple(inputs.shape))
+        normalized_ids.append(id(inputs))
         return normalize(inputs, *args, **kwargs)
 
     monkeypatch.setattr(torch.nn.functional, "normalize", track_normalize)
 
     embedder(field)
 
-    assert normalized_shapes == [(field.content.numel(), structure.d_model)]
+    assert content_id not in normalized_ids
+
+
+def test_category_embedder_content_directions_are_unit_at_init():
+    structure = Schema.model_validate(_structure_payload(p_unavailable=0.0))
+    embedder = Embedder(schema=structure, address=ADDRESS)
+
+    norms = embedder.content_directions().norm(dim=-1)
+
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-6)
+
+
+def test_category_normalize_content_directions_restores_unit_rows():
+    structure = Schema.model_validate(_structure_payload(p_unavailable=0.0))
+    embedder = Embedder(schema=structure, address=ADDRESS)
+
+    with torch.no_grad():
+        embedder.embeddings[TensorKey.content.name].weight.mul_(3.0)
+
+    pre_norms = embedder.content_directions().norm(dim=-1)
+    assert torch.allclose(pre_norms, torch.full_like(pre_norms, 3.0), atol=1e-6)
+
+    embedder.normalize_content_directions()
+
+    post_norms = embedder.content_directions().norm(dim=-1)
+    assert torch.allclose(post_norms, torch.ones_like(post_norms), atol=1e-6)
 
 
 def test_category_cosface_is_finite_for_zero_float16_query_and_gradient():

--- a/tests/tensorfields/extensions/test_category.py
+++ b/tests/tensorfields/extensions/test_category.py
@@ -4,7 +4,7 @@ import polars as pl
 import torch
 from tensordict import TensorDict
 
-from relflow.structs.enums import Strata, TensorKey, Tokens
+from relflow.structs.enums import Metric, Strata, TensorKey, Tokens
 from relflow.structs.experiment import Schema
 from relflow.structs.packages import Prediction
 from relflow.tensorfields.extensions.category import (
@@ -200,7 +200,7 @@ def test_category_embedder_and_decoder_use_real_vocab_width():
 
     assert embedder.embeddings[TensorKey.content.name].num_embeddings == request.size
     assert embedder.counters[TensorKey.content.name].size == request.size
-    assert decoder.linears[TensorKey.content.name].out_features == request.size
+    assert decoder.linears[TensorKey.content.name].out_features == structure.d_model
 
 
 def test_category_embedder_zeroes_unavailable_and_non_valued_content_contributions():
@@ -239,39 +239,48 @@ class _DummyVocab:
         return ["ALPHA", "BETA", "GAMMA", "DELTA", "EPS"]
 
 
-class _DummyEmbedder:
-    def __init__(self):
-        self.vocab = _DummyVocab()
+def _dummy_write_module(*, d_model: int = 4, scale: float = 30.0, topk: list[int] | None = None):
+    payload = _structure_payload(topk=topk or [2, 3, 5])
+    payload["d_model"] = d_model
+    payload["fields"]["fields"][0]["fields"][0]["size"] = d_model
+    structure = Schema.model_validate(payload)
+    structure.requests[ADDRESS].scale = scale
+
+    embedder = Embedder(schema=structure, address=ADDRESS)
+    for token in _DummyVocab().snapshot():
+        embedder.vocab.state.reserve(token, learn=True)
+
+    with torch.no_grad():
+        weight = embedder.embeddings[TensorKey.content.name].weight
+        weight.zero_()
+        for index in range(len(_DummyVocab().snapshot())):
+            weight[index, index] = 1.0
+
+    module = SimpleNamespace(
+        nodes={ADDRESS: SimpleNamespace(embedder=embedder)},
+        schema=structure,
+    )
+    return module, embedder, d_model
 
 
-class _DummyNode:
-    def __init__(self):
-        self.embedder = _DummyEmbedder()
-
-
-class _DummyModule:
-    def __init__(self):
-        self.nodes = {ADDRESS: _DummyNode()}
-        self.schema = SimpleNamespace(requests={ADDRESS: SimpleNamespace(topk=[2, 3, 5, 10], size=8)})
+def _basis_query(shape: tuple[int, ...], index: int, d_model: int) -> torch.Tensor:
+    query = torch.zeros(*shape, d_model)
+    query[..., index] = 1.0
+    return query
 
 
 def test_category_write_emits_state_and_content_payloads():
-    module = _DummyModule()
+    module, _embedder, d_model = _dummy_write_module(d_model=8, topk=[2, 3, 5])
     state_logits = torch.zeros(2, 1, len(Tokens))
     state_logits[0, 0, Tokens.valued.value] = 10.0
     state_logits[1, 0, Tokens.padded.value] = 10.0
-    content_logits = torch.tensor(
-        [
-            [[0.1, 0.9, 0.2, 0.3, 0.4, 0.0, 0.0, 0.0]],
-            [[0.1, 0.2, 0.8, 0.3, 0.4, 0.0, 0.0, 0.0]],
-        ]
-    )
+    content_query = torch.stack([_basis_query((1,), 1, d_model), _basis_query((1,), 2, d_model)], dim=0)
     prediction = Prediction(
         address=ADDRESS,
         payload=TensorDict(
             {
                 TensorKey.state: state_logits,
-                TensorKey.content: content_logits,
+                TensorKey.content: content_query,
             },
             batch_size=[2],
         ),
@@ -303,15 +312,15 @@ def test_category_write_emits_state_and_content_payloads():
 
 
 def test_category_write_ignores_logits_beyond_vocabulary_snapshot():
-    module = _DummyModule()
+    module, _embedder, d_model = _dummy_write_module(d_model=8, topk=[2, 3, 5])
+    query = _basis_query((1, 1), 4, d_model)
     state_logits = torch.zeros(1, 1, len(Tokens))
-    content_logits = torch.tensor([[[0.1, 0.2, 0.3, 0.4, 0.5, 0.0, 0.0, 100.0]]])
     prediction = Prediction(
         address=ADDRESS,
         payload=TensorDict(
             {
                 TensorKey.state: state_logits,
-                TensorKey.content: content_logits,
+                TensorKey.content: query,
             },
             batch_size=[1],
         ),
@@ -359,7 +368,7 @@ def test_category_loss_does_not_mutate_counters():
                 TensorKey.state: torch.zeros(*field.state.shape, len(Tokens)),
                 TensorKey.content: torch.zeros(
                     *field.content.shape,
-                    structure.requests[ADDRESS].size,
+                    structure.d_model,
                 ),
             },
             batch_size=field.batch_size,
@@ -406,7 +415,7 @@ def test_category_loss_uses_uniform_target_for_unavailable_content():
         payload=TensorDict(
             {
                 TensorKey.state: torch.zeros(*field.state.shape, len(Tokens)),
-                TensorKey.content: torch.zeros(*field.content.shape, structure.requests[ADDRESS].size),
+                TensorKey.content: torch.zeros(*field.content.shape, structure.d_model),
             },
             batch_size=field.batch_size,
         ),
@@ -419,3 +428,44 @@ def test_category_loss_uses_uniform_target_for_unavailable_content():
         module.tracked[(ADDRESS, Strata.validate, "vocabulary", "size")],
         torch.tensor(0.0),
     )
+
+
+def test_category_content_loss_stays_finite_and_bounded_for_large_vocabulary():
+    payload = _structure_payload(p_unavailable=0.0)
+    payload["fields"]["fields"][0]["fields"][0]["size"] = 4096
+    structure = Schema.model_validate(payload)
+    d_model = structure.d_model
+    scale = structure.requests[ADDRESS].scale
+    state = _state(size=structure.requests[ADDRESS].size)
+
+    field = TensorField.new(
+        values=[[["ALPHA", "BETA"]], [["GAMMA", "DELTA"]]],
+        address=ADDRESS,
+        schema=structure,
+        strata=Strata.train,
+        interprocess_encoding_context=state,
+    )
+    field.mask(1.0)
+
+    embedder = Embedder(schema=structure, address=ADDRESS)
+    decoder = Decoder(schema=structure, address=ADDRESS)
+    module = _TrackingModule(schema=structure, embedder=embedder, decoder=decoder)
+
+    torch.manual_seed(0)
+    prediction = Prediction(
+        address=ADDRESS,
+        payload=TensorDict(
+            {
+                TensorKey.state: torch.zeros(*field.state.shape, len(Tokens)),
+                TensorKey.content: torch.randn(*field.content.shape, d_model),
+            },
+            batch_size=field.batch_size,
+        ),
+    )
+
+    result = loss(module=module, prediction=prediction, batch=field, strata=Strata.train)
+
+    assert torch.isfinite(result)
+    tracked_content = module.tracked[(ADDRESS, Strata.train, Metric.loss, TensorKey.content)]
+    assert torch.isfinite(tracked_content)
+    assert tracked_content.item() <= 2.0 * scale + float(torch.log(torch.tensor(4096.0))) + 5.0

--- a/tests/tensorfields/extensions/test_category.py
+++ b/tests/tensorfields/extensions/test_category.py
@@ -234,6 +234,97 @@ def test_category_embedder_zeroes_unavailable_and_non_valued_content_contributio
     assert torch.allclose(output, expected)
 
 
+def test_category_embedder_only_adds_content_for_available_valued_tokens():
+    structure = Schema.model_validate(_structure_payload(p_unavailable=0.0))
+    embedder = Embedder(schema=structure, address=ADDRESS)
+    unavailable = structure.requests[ADDRESS].size
+    field = TensorField(
+        state=torch.tensor(
+            [
+                [
+                    Tokens.valued.value,
+                    Tokens.valued.value,
+                    Tokens.null.value,
+                    Tokens.padded.value,
+                    Tokens.masked.value,
+                    Tokens.other.value,
+                ]
+            ],
+            dtype=torch.int64,
+        ),
+        content=torch.tensor([[2, unavailable, 3, 4, 5, 6]], dtype=torch.int64),
+        trainable=torch.zeros((1, 6), dtype=torch.bool),
+        targets=TensorDict({}),
+        batch_size=1,
+    )
+
+    output = embedder(field).payload
+    state_embedding = embedder.embeddings[TensorKey.state.name](field.state)
+    content_contribution = output - state_embedding
+    expected = torch.zeros_like(content_contribution)
+    expected[0, 0] = torch.nn.functional.normalize(
+        embedder.embeddings[TensorKey.content.name].weight[2],
+        dim=-1,
+    )
+
+    assert torch.allclose(content_contribution, expected, atol=1e-6)
+    assert torch.allclose(content_contribution[0, 0].norm(), torch.tensor(1.0))
+
+    output.sum().backward()
+    content_gradient = embedder.embeddings[TensorKey.content.name].weight.grad
+    state_gradient = embedder.embeddings[TensorKey.state.name].weight.grad
+    assert content_gradient is not None
+    assert state_gradient is not None
+    assert content_gradient[2].abs().sum() > 0
+    assert torch.count_nonzero(content_gradient[:2]) == 0
+    assert torch.count_nonzero(content_gradient[3:]) == 0
+    assert torch.all(state_gradient.abs().sum(dim=-1) > 0)
+
+
+def test_category_embedder_normalizes_looked_up_rows_instead_of_full_table(monkeypatch):
+    structure = Schema.model_validate(_structure_payload(p_unavailable=0.0))
+    embedder = Embedder(schema=structure, address=ADDRESS)
+    field = TensorField(
+        state=torch.tensor([[Tokens.valued.value, Tokens.null.value]], dtype=torch.int64),
+        content=torch.tensor([[1, 0]], dtype=torch.int64),
+        trainable=torch.zeros((1, 2), dtype=torch.bool),
+        targets=TensorDict({}),
+        batch_size=1,
+    )
+    normalized_shapes: list[tuple[int, ...]] = []
+    normalize = torch.nn.functional.normalize
+
+    def track_normalize(inputs: torch.Tensor, *args, **kwargs):
+        normalized_shapes.append(tuple(inputs.shape))
+        return normalize(inputs, *args, **kwargs)
+
+    monkeypatch.setattr(torch.nn.functional, "normalize", track_normalize)
+
+    embedder(field)
+
+    assert normalized_shapes == [(field.content.numel(), structure.d_model)]
+
+
+def test_category_cosface_is_finite_for_zero_float16_query_and_gradient():
+    structure = Schema.model_validate(_structure_payload(p_unavailable=0.0))
+    embedder = Embedder(schema=structure, address=ADDRESS).half()
+    query = torch.zeros(2, structure.d_model, dtype=torch.float16, requires_grad=True)
+
+    cosine = embedder.content_cosine(query)
+    targets = torch.tensor([0, 1])
+    one_hot = torch.nn.functional.one_hot(targets, num_classes=embedder.size)
+    logits = structure.requests[ADDRESS].scale * (cosine - embedder.margin * one_hot)
+    content_loss = torch.nn.functional.cross_entropy(logits, targets)
+    content_loss.backward()
+
+    assert torch.isfinite(cosine).all()
+    assert torch.count_nonzero(cosine) == 0
+    assert query.grad is not None
+    assert torch.isfinite(query.grad).all()
+    assert embedder.embeddings[TensorKey.content.name].weight.grad is not None
+    assert torch.isfinite(embedder.embeddings[TensorKey.content.name].weight.grad).all()
+
+
 class _DummyVocab:
     def snapshot(self) -> list[str]:
         return ["ALPHA", "BETA", "GAMMA", "DELTA", "EPS"]
@@ -427,6 +518,168 @@ def test_category_loss_uses_uniform_target_for_unavailable_content():
     assert torch.allclose(
         module.tracked[(ADDRESS, Strata.validate, "vocabulary", "size")],
         torch.tensor(0.0),
+    )
+    assert torch.allclose(
+        module.tracked[(ADDRESS, Strata.validate, Metric.loss, TensorKey.content)],
+        torch.log(torch.tensor(float(structure.requests[ADDRESS].size))),
+    )
+
+
+def test_category_loss_scores_only_valued_targets_and_matches_cosface_reference(monkeypatch):
+    structure = Schema.model_validate(_structure_payload(p_unavailable=0.0))
+    state = _state(size=structure.requests[ADDRESS].size)
+    field = TensorField.new(
+        values=[[["ALPHA", None]], [["BETA"]]],
+        address=ADDRESS,
+        schema=structure,
+        strata=Strata.train,
+        interprocess_encoding_context=state,
+    )
+    field.mask(1.0)
+    valued = field.trainable & field.targets[TensorKey.state].eq(Tokens.valued.value)
+    valued_indices = valued.reshape(-1).nonzero().flatten()
+    field.targets[TensorKey.content].reshape(-1)[valued_indices[-1]] = structure.requests[ADDRESS].size
+
+    embedder = Embedder(schema=structure, address=ADDRESS)
+    decoder = Decoder(schema=structure, address=ADDRESS)
+    module = _TrackingModule(schema=structure, embedder=embedder, decoder=decoder)
+    torch.manual_seed(0)
+    content_query = torch.randn(*field.content.shape, structure.d_model, requires_grad=True)
+    prediction = Prediction(
+        address=ADDRESS,
+        payload=TensorDict(
+            {
+                TensorKey.state: torch.zeros(*field.state.shape, len(Tokens)),
+                TensorKey.content: content_query,
+            },
+            batch_size=field.batch_size,
+        ),
+    )
+
+    state_targets = field.targets[TensorKey.state]
+    valued = field.trainable & state_targets.eq(Tokens.valued.value)
+    valued_query = content_query[valued]
+    valued_targets = field.targets[TensorKey.content][valued]
+    cosine = embedder.content_cosine(valued_query)
+    available = valued_targets.lt(structure.requests[ADDRESS].size)
+    unavailable = valued_targets.eq(structure.requests[ADDRESS].size)
+    cos_available = cosine[available]
+    tgt_available = valued_targets[available]
+    one_hot = torch.nn.functional.one_hot(
+        tgt_available,
+        num_classes=structure.requests[ADDRESS].size,
+    )
+    reference_logits = structure.requests[ADDRESS].scale * (cos_available - embedder.margin * one_hot)
+    reference_available_loss = torch.nn.functional.cross_entropy(
+        input=reference_logits,
+        target=tgt_available,
+        weight=embedder.counters[TensorKey.content.name].weight,
+        reduction="none",
+    ).sum()
+    reference_unavailable_loss = (
+        -torch.nn.functional.log_softmax(
+            structure.requests[ADDRESS].scale * cosine[unavailable],
+            dim=1,
+        )
+        .mean(dim=1)
+        .sum()
+    )
+    reference_loss = (reference_available_loss + reference_unavailable_loss) / valued_targets.numel()
+    reference_query_gradient, reference_weight_gradient = torch.autograd.grad(
+        reference_loss,
+        (
+            content_query,
+            embedder.embeddings[TensorKey.content.name].weight,
+        ),
+        retain_graph=True,
+    )
+
+    query_shapes: list[tuple[int, ...]] = []
+    content_cosine = embedder.content_cosine
+
+    def track_content_cosine(query: torch.Tensor, indices: torch.Tensor | None = None):
+        query_shapes.append(tuple(query.shape))
+        return content_cosine(query=query, indices=indices)
+
+    monkeypatch.setattr(embedder, "content_cosine", track_content_cosine)
+
+    loss(module=module, prediction=prediction, batch=field, strata=Strata.train)
+    optimized_loss = module.tracked[(ADDRESS, Strata.train, Metric.loss, TensorKey.content)]
+    optimized_query_gradient, optimized_weight_gradient = torch.autograd.grad(
+        optimized_loss,
+        (
+            content_query,
+            embedder.embeddings[TensorKey.content.name].weight,
+        ),
+    )
+
+    assert query_shapes == [(int(valued.sum()), structure.d_model)]
+    assert torch.allclose(optimized_loss, reference_loss)
+    assert torch.allclose(optimized_query_gradient, reference_query_gradient)
+    assert torch.allclose(optimized_weight_gradient, reference_weight_gradient)
+    assert torch.count_nonzero(optimized_query_gradient[~valued]) == 0
+    assert torch.allclose(
+        module.tracked[(ADDRESS, Strata.train, "embedding", "valued_state_norm")],
+        embedder.embeddings[TensorKey.state.name].weight[Tokens.valued.value].norm(),
+    )
+
+
+def test_category_loss_reuses_nested_rankings_and_excludes_unavailable_from_metrics():
+    payload = _structure_payload(topk=[2, 3], p_unavailable=0.0)
+    payload["d_model"] = 8
+    structure = Schema.model_validate(payload)
+    embedder = Embedder(schema=structure, address=ADDRESS)
+    decoder = Decoder(schema=structure, address=ADDRESS)
+    module = _TrackingModule(schema=structure, embedder=embedder, decoder=decoder)
+    unavailable = structure.requests[ADDRESS].size
+    with torch.no_grad():
+        embedder.embeddings[TensorKey.content.name].weight.copy_(torch.eye(8))
+
+    field = TensorField(
+        state=torch.full((1, 3), Tokens.masked.value, dtype=torch.int64),
+        content=torch.zeros((1, 3), dtype=torch.int64),
+        trainable=torch.ones((1, 3), dtype=torch.bool),
+        targets=TensorDict(
+            {
+                TensorKey.state: torch.full((1, 3), Tokens.valued.value, dtype=torch.int64),
+                TensorKey.content: torch.tensor([[0, 1, unavailable]], dtype=torch.int64),
+            }
+        ),
+        batch_size=1,
+    )
+    content_query = torch.tensor(
+        [
+            [
+                [0.3, 0.9, 0.8, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        ]
+    )
+    prediction = Prediction(
+        address=ADDRESS,
+        payload=TensorDict(
+            {
+                TensorKey.state: torch.zeros(1, 3, len(Tokens)),
+                TensorKey.content: content_query,
+            },
+            batch_size=1,
+        ),
+    )
+
+    loss(module=module, prediction=prediction, batch=field, strata=Strata.train)
+
+    assert torch.allclose(
+        module.tracked[(ADDRESS, Strata.train, Metric.accuracy, TensorKey.content)],
+        torch.tensor(0.5),
+    )
+    assert torch.allclose(
+        module.tracked[(ADDRESS, Strata.train, Metric.accuracy, "top2")],
+        torch.tensor(0.5),
+    )
+    assert torch.allclose(
+        module.tracked[(ADDRESS, Strata.train, Metric.accuracy, "top3")],
+        torch.tensor(1.0),
     )
 
 


### PR DESCRIPTION
By implementing an extension of the CosFace algorithm (Wang et al 2018) and the MCML penalty as a learning objective, this update for the categorical data type is aimed to provide more semantically interpretable embeddings while also more consistently providing monotonic convergence patterns during pre-training. The issue in the existing approach is that the expansion of new vocabulary for the online vocabulary causes an issue in which loss values grow over time as new vocabulary is learned, leading to EarlyStopping. Proofs provided in the original papers appendix support the default args, but this update does introduce two new hyper parameters relevant for categorical data types. 

We should question whether we want to implement this change as well for the set datatype, or if Categorical will now diverge from Set in this way. @granthamtaylor, thoughts?

Instead of hard-parameterizing embedding table to unit norm hypersphere, we opt to init the embedding table to this value, and then to normalize the values at each forward such that we only consider the projection of the embedding values upon the hypersphere. However, by not enforcing this hypersphere fixation on train batch end, we allow the model to more accurately leverage Adam optimizer steps and we provide greater stability more generally. There is also a geometric edge case in which the randomly initialized projection upon the hypersphere is encouraged to move to the extreme opposite end of the unit circle. By allowing semantic clusters to migrate freely, since loss is only considered by the angular measures of clusters and not radial measures, I hypothesize that we more freely allow semantic meaning to emerge under even extreme cases.